### PR TITLE
[Chore] Parallel jobs for CI & CD

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
 jobs:
-  build:
+  deploy:
     name: "Install/Pre-Deploy/Deploy"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -5,30 +5,34 @@ on:
       - master
 jobs:
   deploy:
-    name: "Install/Pre-Deploy/Deploy"
+    name: "Install > Deploy"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        firebase_component: ['hosting', 'functions', 'firestore', 'storage']
     steps:
-      - uses: actions/checkout@v2
-        name: Checkout the code
-      - uses: actions/setup-node@v1
-        name: Setup node v10.x environment
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Setup node v10.x environment
+        uses: actions/setup-node@v1
         with:
           node-version: '10.x'
-      - uses: actions/cache@master
-        name: Restore lerna-style dependencies
+      - name: Restore lerna-style dependencies
+        uses: actions/cache@master
         id: lerna_cache
         with:
           path: |
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn
-        name: Install root package dependencies
+      - name: Install root package dependencies
+        run: yarn install
         if: steps.lerna_cache.outputs.cache-hit != 'true'
-      - run: yarn bootstrap
-        name: Install inner package dependencies
+      - name: Install inner package dependencies
+        run: yarn run bootstrap
         if: steps.lerna_cache.outputs.cache-hit != 'true'
-      - run: yarn deploy:ci --token=$FIREBASE_TOKEN
-        name: Deploy inner packages code
+      - name: Deploy ${{ matrix.firebase_component }} to Firebase
+        run: yarn deploy:ci --token=$FIREBASE_TOKEN --only ${{ matrix.firebase_component }}
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,8 +4,8 @@ on:
     branches-ignore:
       - master
 jobs:
-  build:
-    name: "Install/Lint/Format/Build/Test"
+  install-dependencies:
+    name: "Install"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -28,11 +28,31 @@ jobs:
       - run: yarn bootstrap
         name: Install inner package dependencies
         if: steps.lerna_cache.outputs.cache-hit != 'true'
+  lint:
+    name: "Lint"
+    runs-on: ubuntu-latest
+    needs: install-dependencies
+    steps:
       - run: yarn lint
         name: Lint inner packages code
+  format:
+    name: "Format"
+    runs-on: ubuntu-latest
+    needs: install-dependencies
+    steps:
       - run: yarn format
         name: Format inner packages code
+  build:
+    name: "Build"
+    runs-on: ubuntu-latest
+    needs: install-dependencies
+    steps:
       - run: yarn build
         name: Build inner packages code
+  test:
+    name: "Test"
+    runs-on: ubuntu-latest
+    needs: install-dependencies
+    steps:
       - run: yarn test:ci
         name: Test inner packages code

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
+      - name: Setup node v10.x environment
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
       - name: Restore lerna-style dependencies
         uses: actions/cache@master
         id: lerna_cache
@@ -23,7 +27,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install root package dependencies
-        run: yarn
+        run: yarn install
         if: steps.lerna_cache.outputs.cache-hit != 'true'
       - name: Install inner package dependencies
         run: yarn bootstrap

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   install-dependencies:
-    name: "Install/(Lint|Format|Build|Test)"
+    name: "Install >"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,25 +12,21 @@ jobs:
       matrix:
         script: ['lint', 'format', 'build', 'test:ci']
     steps:
-      - uses: actions/checkout@v2
-        name: Checkout the code
-      - uses: actions/setup-node@v1
-        name: Setup node v10.x environment
-        with:
-          node-version: '10.x'
-      - uses: actions/cache@master
-        name: Restore lerna-style dependencies
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Restore lerna-style dependencies
+        uses: actions/cache@master
         id: lerna_cache
         with:
           path: |
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn
-        name: Install root package dependencies
+      - name: Install root package dependencies
+        run: yarn
         if: steps.lerna_cache.outputs.cache-hit != 'true'
-      - run: yarn bootstrap
-        name: Install inner package dependencies
+      - name: Install inner package dependencies
+        run: yarn bootstrap
         if: steps.lerna_cache.outputs.cache-hit != 'true'
-      - run: yarn ${{ matrix.script }}
-        name: Run ${{ matrix.script }} on inner packages code
+      - name: Run ${{ matrix.script }} on inner packages code
+        run: yarn run ${{ matrix.script }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        script: [lint, format, build, test:ci]
+        script: ['lint', 'format', 'build', 'test:ci']
     steps:
       - uses: actions/checkout@v2
         name: Checkout the code

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,8 +5,12 @@ on:
       - master
 jobs:
   install-dependencies:
-    name: "Install"
+    name: "Install/(Lint|Format|Build|Test)"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        script: [lint, format, build, test:ci]
     steps:
       - uses: actions/checkout@v2
         name: Checkout the code
@@ -28,31 +32,5 @@ jobs:
       - run: yarn bootstrap
         name: Install inner package dependencies
         if: steps.lerna_cache.outputs.cache-hit != 'true'
-  lint:
-    name: "Lint"
-    runs-on: ubuntu-latest
-    needs: install-dependencies
-    steps:
-      - run: yarn lint
-        name: Lint inner packages code
-  format:
-    name: "Format"
-    runs-on: ubuntu-latest
-    needs: install-dependencies
-    steps:
-      - run: yarn format
-        name: Format inner packages code
-  build:
-    name: "Build"
-    runs-on: ubuntu-latest
-    needs: install-dependencies
-    steps:
-      - run: yarn build
-        name: Build inner packages code
-  test:
-    name: "Test"
-    runs-on: ubuntu-latest
-    needs: install-dependencies
-    steps:
-      - run: yarn test:ci
-        name: Test inner packages code
+      - run: yarn ${{ matrix.script }}
+        name: Run ${{ matrix.script }} on inner packages code

--- a/firebase/storage.rules
+++ b/firebase/storage.rules
@@ -1,3 +1,4 @@
+rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "repository": "git@github.com:UriellViana/firebase-lerna-boilerplate.git",
   "license": "MIT",
   "private": true,
+  "engines": {
+    "node": "10"
+  },
   "scripts": {
     "firebase": "firebase",
     "deploy": "firebase deploy",

--- a/packages/hosting/package.json
+++ b/packages/hosting/package.json
@@ -2,6 +2,9 @@
   "name": "hosting",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": "10"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
Now we can run continuous integration jobs in parallel for faster validation, as well as continuous deployment of multiple Firebase components at once.